### PR TITLE
fix(tools): separate tools job

### DIFF
--- a/packages/agent/src/agents/operators/supervisor/tools/createAgentTool.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/createAgentTool.ts
@@ -1,7 +1,6 @@
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import {
   AgentConfig,
-  McpServerConfig,
   logger,
   validateAgent,
   validateAgentQuotas,
@@ -29,7 +28,7 @@ export function createAgentTool(
   return new DynamicStructuredTool({
     name: 'create_agent',
     description:
-      'Create/add/make a new agent configuration for a specific user. Provide the agent profile (name, group, description) and optional configuration overrides for graph, memory, rag, plugins, mcp_servers, and prompts.',
+      'Create a new agent configuration with default settings. Only accepts agent profile (name, group, description, contexts). All other configuration (graph, memory, rag, mcp_servers) will use default values. To modify configuration after creation, use update_agent tool.',
     schema: CreateAgentSchema,
     func: async (rawInput) => {
       let input: CreateAgentInput;
@@ -167,52 +166,20 @@ export function createAgentTool(
 }
 
 function buildAgentConfigFromInput(input: CreateAgentInput): AgentConfig.Input {
-  // Build partial config from input - normalizeNumericValues will handle the rest
-  const partialConfig: Partial<AgentConfig.Input> = {};
-
-  // Only add properties that are actually provided
-  if (input.profile) {
-    partialConfig.profile = {
+  // Build partial config from input - only profile and prompts_id are allowed
+  const partialConfig: Partial<AgentConfig.Input> = {
+    profile: {
       name: input.profile.name.trim(),
       group: input.profile.group.trim(),
       description: input.profile.description.trim(),
       contexts: input.profile.contexts || [],
-    };
+    },
+  };
+
+  // Include prompts_id if provided
+  if (input.prompts_id) {
+    partialConfig.prompts_id = input.prompts_id;
   }
-
-  if (input.mcp_servers) {
-    // Convert array to Record<string, McpServerConfig>
-    const mcpServersRecord: Record<string, McpServerConfig> = {};
-    for (const server of input.mcp_servers) {
-      const { name, env, ...serverConfig } = server;
-
-      // Convert env array to Record<string, string>
-      let envRecord: Record<string, string> | undefined;
-      if (env && Array.isArray(env)) {
-        envRecord = {};
-        for (const envEntry of env) {
-          envRecord[envEntry.name] = envEntry.value;
-        }
-      }
-
-      mcpServersRecord[name] = {
-        ...serverConfig,
-        ...(envRecord && { env: envRecord }),
-      };
-    }
-
-    partialConfig.mcp_servers = parseMcpServers(mcpServersRecord, {});
-  }
-
-  if (input.graph)
-    partialConfig.graph = input.graph as AgentConfig.Input['graph'];
-
-  if (input.memory)
-    partialConfig.memory = input.memory as AgentConfig.Input['memory'];
-
-  if (input.rag) partialConfig.rag = input.rag;
-
-  if (input.prompts_id) partialConfig.prompts_id = input.prompts_id;
 
   // Apply normalization using the centralized function - it handles all defaults and validation
   const { normalizedConfig, appliedDefaults } =
@@ -226,16 +193,6 @@ function buildAgentConfigFromInput(input: CreateAgentInput): AgentConfig.Input {
   }
 
   return normalizedConfig;
-}
-
-function parseMcpServers(
-  value: Record<string, McpServerConfig> | undefined,
-  fallback: Record<string, McpServerConfig>
-): Record<string, McpServerConfig> {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value;
-  }
-  return { ...fallback };
 }
 
 async function resolveUniqueAgentName(

--- a/packages/agent/src/agents/operators/supervisor/tools/createAgentTool.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/createAgentTool.ts
@@ -104,10 +104,8 @@ export function createAgentTool(
           notes.push(nameNote);
         }
 
-        const { id: promptId, created: promptsCreated } = await ensurePromptsId(
-          userId,
-          input.prompts_id
-        );
+        const { id: promptId, created: promptsCreated } =
+          await ensurePromptsId(userId);
         if (promptsCreated) {
           notes.push('Default prompts initialized for the user.');
         }
@@ -175,11 +173,6 @@ function buildAgentConfigFromInput(input: CreateAgentInput): AgentConfig.Input {
       contexts: input.profile.contexts || [],
     },
   };
-
-  // Include prompts_id if provided
-  if (input.prompts_id) {
-    partialConfig.prompts_id = input.prompts_id;
-  }
 
   // Apply normalization using the centralized function - it handles all defaults and validation
   const { normalizedConfig, appliedDefaults } =

--- a/packages/agent/src/agents/operators/supervisor/tools/schemas/createAgent.schema.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/schemas/createAgent.schema.ts
@@ -7,11 +7,6 @@ export const CreateAgentSchema = z
     profile: AgentProfileSchema.describe(
       'Agent profile configuration (required)'
     ),
-    prompts_id: z
-      .string()
-      .uuid()
-      .optional()
-      .describe('Existing prompts configuration identifier (optional)'),
   })
   .strict();
 

--- a/packages/agent/src/agents/operators/supervisor/tools/schemas/createAgent.schema.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/schemas/createAgent.schema.ts
@@ -1,27 +1,17 @@
 import { z } from 'zod';
-import {
-  AgentProfileSchema,
-  GraphConfigSchema,
-  MemoryConfigSchema,
-  RAGConfigSchema,
-  McpServersArraySchema,
-} from './common.schemas.js';
+import { AgentProfileSchema } from './common.schemas.js';
 
-// Main schema for creating an agent (profile required, other fields optional)
+// Main schema for creating an agent (only profile and prompts_id allowed)
 export const CreateAgentSchema = z
   .object({
-    profile: AgentProfileSchema.describe('Agent profile configuration'),
-    mcp_servers: McpServersArraySchema.optional().describe(
-      'MCP servers configuration'
+    profile: AgentProfileSchema.describe(
+      'Agent profile configuration (required)'
     ),
-    memory: MemoryConfigSchema.optional().describe('Memory configuration'),
-    rag: RAGConfigSchema.optional().describe('RAG configuration'),
     prompts_id: z
       .string()
       .uuid()
       .optional()
-      .describe('Existing prompts configuration identifier'),
-    graph: GraphConfigSchema.optional().describe('Graph configuration'),
+      .describe('Existing prompts configuration identifier (optional)'),
   })
   .strict();
 

--- a/packages/agent/src/agents/operators/supervisor/tools/schemas/updateAgent.schema.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/schemas/updateAgent.schema.ts
@@ -4,23 +4,17 @@ import {
   GraphConfigSchema,
   MemoryConfigSchema,
   RAGConfigSchema,
-  McpServerConfigSchema,
   SelectAgentSchema,
-  McpServersArraySchema,
 } from './common.schemas.js';
-import { getGuardValue } from '@snakagent/core';
 
-const maxMcpServer = getGuardValue('agents.mcp_servers.max_servers');
 // Schema for update agent - allows partial updates with nullable fields
+// Note: mcp_servers is NOT included here - use add_mcp_server, update_mcp_server, or remove_mcp_server tools instead
 export const UpdateAgentSchema = SelectAgentSchema.extend({
   updates: z
     .object({
       profile: AgentProfileSchema.partial()
         .optional()
         .describe('Agent profile configuration (partial)'),
-      mcp_servers: McpServersArraySchema.optional().describe(
-        'MCP servers configuration'
-      ),
       memory: MemoryConfigSchema.optional().describe('Memory configuration'),
       rag: RAGConfigSchema.optional().describe('RAG configuration'),
       prompts_id: z

--- a/packages/agent/src/agents/operators/supervisor/tools/updateAgentTool.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/updateAgentTool.ts
@@ -49,7 +49,7 @@ export function updateAgentTool(
   return new DynamicStructuredTool({
     name: 'update_agent',
     description:
-      'Update/modify/change/rename specific properties of an existing agent configuration. Use when user wants to modify, change, update, edit, or rename any agent property like name, description, group, etc.',
+      'Update/modify/change/rename specific properties of an existing agent configuration. Use when user wants to modify, change, update, edit, or rename any agent property like name, description, group, etc. Note: MCP servers cannot be updated with this tool - use add_mcp_server, update_mcp_server, or remove_mcp_server tools instead.',
     schema: UpdateAgentSchema,
     func: async (input) => {
       try {

--- a/packages/agent/src/agents/operators/supervisor/tools/updateAgentTool.ts
+++ b/packages/agent/src/agents/operators/supervisor/tools/updateAgentTool.ts
@@ -49,7 +49,7 @@ export function updateAgentTool(
   return new DynamicStructuredTool({
     name: 'update_agent',
     description:
-      'Update/modify/change/rename specific properties of an existing agent configuration. Use when user wants to modify, change, update, edit, or rename any agent property like name, description, group, etc. Note: MCP servers cannot be updated with this tool - use add_mcp_server, update_mcp_server, or remove_mcp_server tools instead.',
+      'Update/modify/change/rename specific properties of an existing agent configuration. Use when user wants to modify, change, update, edit, or rename any agent property like name, description, group, etc.',
     schema: UpdateAgentSchema,
     func: async (input) => {
       try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent creation simplified: only profile is required; prompts are auto-initialized at creation (no prompts input accepted) and other settings default and must be changed later.
  * MCP server configuration removed from create/update payloads and is now managed via dedicated MCP server tools.

* **Documentation**
  * Notes clarifying that MCP servers cannot be set during creation or via the standard update schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->